### PR TITLE
Introduct MessageId type that can be either int or string.

### DIFF
--- a/include/rpc.h
+++ b/include/rpc.h
@@ -6,8 +6,6 @@
 #include "log.h"
 #include "lsp.h"
 
-// connection
-
 class Connection {
 public:
   Connection(std::istream &in, std::ostream &out, Logger &logger)

--- a/src/lsp.cpp
+++ b/src/lsp.cpp
@@ -2,49 +2,44 @@
 
 namespace lsp {
 
-// Parse bytes into json and construct a Message
-// TODO: maybe use std::optional ?
+// Parse bytes into json and construct a concrete subclass of Message
 std::unique_ptr<Message> Message::parse(const std::string& msg) {
   json data = json::parse(msg);
   if (data.contains("method")) {
-    // TODO: "Notification" message has no "id"
     auto method = data["method"].get<std::string>();
     if (data.contains("id")) {
-      auto id = data["id"].get<std::uint32_t>();
-      return std::make_unique<RequestMessage>(id, method, data);
+      auto id = data["id"].template get<MessageId>();
+      return std::make_unique<RequestMessage>(id, method, std::move(data));
     } else {
-      return std::make_unique<NotificationMessage>(method, data);
+      return std::make_unique<NotificationMessage>(method, std::move(data));
     }
   }
 
   return nullptr;
 }
 
-// TODO: rewrite this with json lib specific to_json
 json RequestMessage::to_json() const {
-  json data = {
+  return json{
       {"jsonrpc", "2.0"},
       {"id", id},
       {"method", method},
   };
-  return data;
 }
 
 json ResponseMessage::to_json() const {
-  json data = {
+  return json{
       {"jsonrpc", "2.0"},
       {"id", id},
       {"result", result},
   };
-  return data;
 }
 
 json NotificationMessage::to_json() const {
-  // TODO: finish
-  json data = {
+  return json{
       {"jsonrpc", "2.0"},
+      {"method", method},
+      {"params", data}
   };
-  return data;
 }
 
 json InitializeResponse::to_json() const {
@@ -58,4 +53,19 @@ json InitializeResponse::to_json() const {
 
   return data;
 }
+
+void from_json(const json &j, InitializeParams &params) {
+    const json &client_info = j.at("params").at("clientInfo");
+    client_info.at("name").get_to(params.client_info.name);
+    client_info.at("version").get_to(params.client_info.version);
+}
+
+void from_json(const json &j, DidOpenTextDocumentParams &params) {
+  const json &text_document = j.at("params").at("textDocument");
+  text_document.at("uri").get_to(params.text_document_item.uri);
+  text_document.at("languageId").get_to(params.text_document_item.language_id);
+  text_document.at("version").get_to(params.text_document_item.version);
+  text_document.at("text").get_to(params.text_document_item.text);
+}
+
 } // namespace lsp

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -8,7 +8,6 @@ void Server::start() {
     if (message != nullptr) {
       handler(*message);
     }
-    // TODO: handle message/send response
   }
 }
 

--- a/tests/test_message.cpp
+++ b/tests/test_message.cpp
@@ -19,10 +19,30 @@ TEST(Message, ParseRequestMessageJson) {
   EXPECT_EQ(msg->get_kind(), lsp::Message::Kind::Request);
 
   auto request = static_cast<lsp::RequestMessage *>(msg.get());
-  EXPECT_EQ(request->id, 1);
+  EXPECT_EQ(std::get<int>(request->id), 1);
   EXPECT_EQ(request->method, "initialize");
   EXPECT_EQ(request->data["params"]["clientInfo"]["name"], "lets-ls");
   EXPECT_EQ(request->data["params"]["clientInfo"]["version"], "0.1.0");
+}
+
+TEST(Message, ParseRequestMessageJsonStringId) {
+  std::string content = R"({
+    "method": "initialize",
+    "id": "1",
+    "params": {
+      "clientInfo": {
+        "name": "lets-ls",
+        "version": "0.1.0"
+      }
+    }
+  })";
+
+  auto msg = lsp::Message::parse(content);
+  ASSERT_NE(msg, nullptr);
+  EXPECT_EQ(msg->get_kind(), lsp::Message::Kind::Request);
+
+  auto request = static_cast<lsp::RequestMessage *>(msg.get());
+  EXPECT_EQ(std::get<std::string>(request->id), "1");
 }
 
 TEST(Message, ParseNotificationMessageJson) {


### PR DESCRIPTION
- Refactor Message class and add support for string or integer message IDs.
- Implement custom ser/de for MessageId variant and update Message::parse method.
- Add test that checks string id deserialisation
